### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Forget about `opensipsctl` and move on to a pleasant console environment!
 
 ```
 # required OS packages
-sudo apt-get install python3 python3-pip python3-dev gcc # Debian & Ubuntu
-sudo yum install python36 python36-pip python36-devel gcc # Red Hat & CentOS
+sudo apt-get install python3 python3-pip python3-dev gcc mysql-devel # Debian & Ubuntu
+sudo yum install python36 python36-pip python36-devel gcc mysql-devel # Red Hat & CentOS
 
 # required Python3 packages
 sudo pip3 install mysqlclient sqlalchemy sqlalchemy-utils

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Forget about `opensipsctl` and move on to a pleasant console environment!
 
 ```
 # required OS packages
-sudo apt-get install python3 python3-pip python3-dev gcc mysql-devel # Debian & Ubuntu
+sudo apt-get install python3 python3-pip python3-dev gcc default-libmysqlclient-dev # Debian & Ubuntu
 sudo yum install python36 python36-pip python36-devel gcc mysql-devel # Red Hat & CentOS
 
 # required Python3 packages


### PR DESCRIPTION
pip3 mysqlclient requires MySQL development headers to be installed.

Resolves installation error:

```
# pip3 install mysqlclient sqlalchemy sqlalchemy-utils
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting mysqlclient
  Using cached https://files.pythonhosted.org/packages/4d/38/c5f8bac9c50f3042c8f05615f84206f77f03db79781db841898fde1bb284/mysqlclient-1.4.4.tar.gz
    Complete output from command python setup.py egg_info:
    /bin/sh: mysql_config: command not found
    /bin/sh: mariadb_config: command not found
    /bin/sh: mysql_config: command not found
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-y54hri9q/mysqlclient/setup.py", line 16, in <module>
        metadata, options = get_config()
      File "/tmp/pip-build-y54hri9q/mysqlclient/setup_posix.py", line 61, in get_config
        libs = mysql_config("libs")
      File "/tmp/pip-build-y54hri9q/mysqlclient/setup_posix.py", line 29, in mysql_config
        raise EnvironmentError("%s not found" % (_mysql_config_path,))
    OSError: mysql_config not found
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-y54hri9q/mysqlclient/
```