### PR TITLE
[diagnose] Fix receiving JSON-RPC from OpenSIPS 3.1

### DIFF
--- a/docs/modules/diagnose.md
+++ b/docs/modules/diagnose.md
@@ -15,8 +15,15 @@ commonly occurring emergencies in production, such as:
 
 ## Configuration
 
-No additional configuration is required by this module.  Its `diagnose load`
-subcommand works best if the `psutil` Python package is present on the system.
+If OpenSIPS CLI is running not on the same host with OpenSIPS, it can accept
+the following parameters in the config file:
+* diagnose_listen_ip - ip address for listening JSON-RPC events from OpenSIPS
+By default ip is `127.0.0.1`
+* diagnose_listen_port - port for listening JSON-RPC events from OpenSIPS
+By default port is `8899`
+
+Subcommand `diagnose load` works best if the `psutil` Python package is present
+on the system.
 
 ## Examples
 

--- a/opensipscli/defaults.py
+++ b/opensipscli/defaults.py
@@ -73,6 +73,10 @@ DEFAULT_VALUES = {
 
     # user module
     "plain_text_passwords": "False",
+
+    # diagnose module
+    "diagnose_listen_ip": "127.0.0.1",
+    "diagnose_listen_port": "8899",
 }
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
* With OpenSIPS 3.1 was changed module name from event_jsonrpc
to event_stream
* Module event_stream now accepts protocol 'tcp' not 'jsonrpc'
* Listening interface was hardcoded to 127.0.0.1:8888 now it
can be changed in config file.