### PR TITLE
Include libs dir into the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,8 @@ setup(
     packages = [
         "opensipscli",
         "opensipscli.modules",
-        "opensipscli.communication"
+        "opensipscli.communication",
+        "opensipscli.libs"
     ],
     install_requires=[
         'mysqlclient<1.4.0rc1',


### PR DESCRIPTION
In commit 77cf8eee93cd808882ec2015c1b862bc95f9de28 sqlalchemy_utils
were added to the libs folder, but this folder was not added to
the package.