### PR TITLE
Creating database using postgres

### DIFF
--- a/docs/modules/database.md
+++ b/docs/modules/database.md
@@ -67,7 +67,7 @@ Consider the following configuration file:
 #database_modules: acc clusterer dialog dialplan dispatcher domain rtpproxy usrloc
 database_modules: ALL
 
-#database_admin_url: postgres://root@localhost
+#database_admin_url: postgresql://root@localhost
 database_admin_url: mysql://root@localhost
 ```
 

--- a/opensipscli/db.py
+++ b/opensipscli/db.py
@@ -45,7 +45,7 @@ except ImportError:
 
 SUPPORTED_BACKENDS = [
     "mysql",
-    "postgres",
+    "postgresql",
     "sqlite",
     "oracle",
 ]
@@ -225,7 +225,7 @@ class osdb(object):
                     raise
                 except:
                     logger.error("unexpected parsing exception")
-            elif self.dialect == "postgres" and \
+            elif self.dialect == "postgresql" and \
                     (("authentication" in se.args[0] and "failed" in se.args[0]) or \
                      ("no password supplied" in se.args[0])):
                 raise osdbAccessDeniedError
@@ -243,7 +243,7 @@ class osdb(object):
         alter attributes of a role object
         """
         # TODO: is any other dialect using the "role" concept?
-        if self.dialect != "postgres":
+        if self.dialect != "postgresql":
             return False
 
         # TODO: do this only for SQLAlchemy
@@ -277,7 +277,7 @@ class osdb(object):
             # TODO: do this only for SQLAlchemy
 
         try:
-            if self.dialect == "postgres":
+            if self.dialect == "postgresql":
                 self.db_url = self.set_url_db(self.db_url, self.db_name)
                 if sqlalchemy_utils.database_exists(self.db_url) is True:
                     engine = sqlalchemy.create_engine(self.db_url, isolation_level='AUTOCOMMIT')
@@ -312,7 +312,7 @@ class osdb(object):
                      self.db_name, self.dialect)
 
         # all good - it's time to create the database
-        if self.dialect == "postgres":
+        if self.dialect == "postgresql":
             self.__conn.connection.connection.set_isolation_level(0)
             try:
                 self.__conn.execute("CREATE DATABASE {}".format(self.db_name))
@@ -408,7 +408,7 @@ class osdb(object):
                 logger.exception("failed to flush privileges")
                 return False
 
-        elif url.drivername.lower() == "postgres":
+        elif url.drivername.lower() == "postgresql":
             if not self.exists_role(url.username):
                 logger.info("creating role %s", url.username)
                 if not self.create_role(url.username, url.password):
@@ -437,7 +437,7 @@ class osdb(object):
         create a role object (PostgreSQL secific)
         """
         # TODO: is any other dialect using the "role" concept?
-        if self.dialect != "postgres":
+        if self.dialect != "postgresql":
             return False
 
         # TODO: do this only for SQLAlchemy
@@ -517,7 +517,7 @@ class osdb(object):
         drop a role object (PostgreSQL specific)
         """
         # TODO: is any other dialect using the "role" concept?
-        if self.dialect != "postgres":
+        if self.dialect != "postgresql":
             return False
 
         # TODO: do this only for SQLAlchemy
@@ -615,7 +615,7 @@ class osdb(object):
         check for existence of a role object (PostgreSQL specific)
         """
         # TODO: is any other dialect using the "role" concept?
-        if self.dialect != "postgres":
+        if self.dialect != "postgresql":
             return False
 
         # TODO: do this only for SQLAlchemy
@@ -696,7 +696,7 @@ class osdb(object):
         get attibutes of a role object (PostgreSQL specific)
         """
         # TODO: is any other dialect using the "role" concept?
-        if self.dialect != "postgres":
+        if self.dialect != "postgresql":
             return False
 
         # TODO: do this only for SQLAlchemy
@@ -721,7 +721,7 @@ class osdb(object):
         assign attibutes to a role object (PostgreSQL specific)
         """
         # TODO: is any other dialect using the "role" concept?
-        if self.dialect != "postgres":
+        if self.dialect != "postgresql":
             return False
 
         # TODO: do this only for SQLAlchemy
@@ -731,7 +731,7 @@ class osdb(object):
         return True
 
     def grant_table_options(self, role, table, privs="ALL PRIVILEGES"):
-        if self.dialect != "postgres":
+        if self.dialect != "postgresql":
             return False
 
         if not self.__conn:
@@ -963,7 +963,7 @@ class osdb(object):
             driver = make_url(url).drivername.lower()
             capitalized = {
                 'mysql': 'MySQL',
-                'postgres': 'PostgreSQL',
+                'postgresql': 'PostgreSQL',
                 'sqlite': 'SQLite',
                 'oracle': 'Oracle',
                 }

--- a/opensipscli/db.py
+++ b/opensipscli/db.py
@@ -739,6 +739,9 @@ class osdb(object):
             return False
 
         return True
+    
+    def grant_public_schema(self, role_name):
+        self.grant_db_options(role_name, "ON SCHEMA public")
 
     def grant_table_options(self, role, table, privs="ALL PRIVILEGES"):
         self.grant_db_options(role, "ON TABLE {}".format(table))

--- a/opensipscli/modules/database.py
+++ b/opensipscli/modules/database.py
@@ -931,8 +931,20 @@ class database(Module):
             logger.error("path '{}' to OpenSIPS DB scripts is not a directory!".
                     format(db_path))
             return None
-
-        schema_path = os.path.join(db_path, backend)
+        
+        def build_schema_path(db_path, backend):
+            """
+            Replaces schema path of postgresql to old postgre schema path if exists.
+            Should be deleted after opensips main repo refactors folder name to the new backend name.
+            """
+            if backend == "postgresql":
+                old_postgre_path = os.path.join(db_path, "postgres")
+                if os.path.isdir(old_postgre_path):
+                    return old_postgre_path
+            schema_path = os.path.join(db_path, backend)
+            return schema_path
+        
+        schema_path = build_schema_path(db_path, backend)
         if not os.path.isdir(schema_path):
             logger.error("invalid OpenSIPS DB scripts dir: '{}'!".
                     format(schema_path))

--- a/opensipscli/modules/database.py
+++ b/opensipscli/modules/database.py
@@ -499,12 +499,12 @@ class database(Module):
 
         if cfg.exists('database_admin_url'):
             admin_url = cfg.get("database_admin_url")
-            if engine == "postgres":
+            if engine == "postgresql":
                 admin_url = osdb.set_url_db(admin_url, 'postgres')
             else:
                 admin_url = osdb.set_url_db(admin_url, None)
         else:
-            if engine == 'postgres':
+            if engine == 'postgresql':
                 if getuser() != "postgres":
                     logger.error("Command must be run as 'postgres' user: "
                                  "sudo -u postgres opensips-cli ...")
@@ -513,7 +513,7 @@ class database(Module):
                 """
                 For PG, do the initial setup using 'postgres' as role + DB
                 """
-                admin_url = "postgres://postgres@localhost/postgres"
+                admin_url = "postgresql://postgres@localhost/postgres"
             else:
                 admin_url = "{}://root@localhost".format(engine)
 
@@ -712,7 +712,7 @@ class database(Module):
             logger.info("Running {}...".format(os.path.basename(table_file)))
             try:
                 db.create_module(table_file)
-                if db.dialect == "postgres":
+                if db.dialect == "postgresql":
                     self.pg_grant_table_access(table_file, username, admin_db)
             except osdbModuleAlreadyExistsError:
                 logger.error("{} table(s) are already created!".format(module))
@@ -772,7 +772,7 @@ class database(Module):
             if db_url is None:
                 return -1
 
-            if db_url.lower().startswith("postgres"):
+            if db_url.lower().startswith("postgresql"):
                 db_url = osdb.set_url_db(db_url, 'postgres')
         else:
             db_url = self.get_db_url(db_name)

--- a/opensipscli/modules/database.py
+++ b/opensipscli/modules/database.py
@@ -707,6 +707,9 @@ class database(Module):
         username = osdb.get_url_user(db_url)
         admin_db.connect(db_name)
 
+        if db.dialect == "postgresql":
+            self.pg_grant_schema(username, admin_db)
+
         # create tables from SQL schemas
         for module, table_file in table_files.items():
             logger.info("Running {}...".format(os.path.basename(table_file)))
@@ -974,3 +977,9 @@ class database(Module):
                 if res:
                     seq = res.group(1)
                     admin_db.grant_table_options(username, seq)
+                    
+    def pg_grant_schema(self, username, admin_db):
+        """
+        Grant access to public schema of DB
+        """
+        admin_db.grant_public_schema(username)

--- a/test/test-database.sh
+++ b/test/test-database.sh
@@ -21,7 +21,7 @@ CLI_CFG=/tmp/.__cli.cfg
 DB_NAME=_opensips_cli_test
 
 MYSQL_URL=mysql://opensips:opensipsrw@localhost
-PGSQL_URL=postgres://opensips:opensipsrw@localhost
+PGSQL_URL=postgresql://opensips:opensipsrw@localhost
 
 TESTS=(
   test_mysql_drop_1_prompt


### PR DESCRIPTION
SQLAlchemy fails to start `postgres` dialect after the dialect is completely removed [(discussion)](https://github.com/sqlalchemy/sqlalchemy/issues/6083#issuecomment-801478013)
According [postgres documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) connection string should use `postgresql`. Current PR #100 does not provide changes is `modules/database.py` file.

In Postgres 15 changed default permission on public schema. It is now necessary grant permissions explicitly. Implemented this behaviour. Closes https://github.com/OpenSIPS/opensips/issues/3120

## Changes
* changed `postgres` to `postgresql` in connection strings
* add legacy support to `postgres` database schema folder until main repo move files to `postgresql` folder
* grant access to public schema for database user
* update docs & test to `postgresql` usage