### PR TITLE
fix a small "os not defined" issue

### DIFF
--- a/opensipscli/libs/sqlalchemy_utils.py
+++ b/opensipscli/libs/sqlalchemy_utils.py
@@ -31,6 +31,7 @@
 
 from copy import copy
 
+import os
 import sqlalchemy as sa
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import OperationalError, ProgrammingError


### PR DESCRIPTION
Following error is thrown when I try to execute `database create`:

```
Traceback (most recent call last):
  File "/usr/bin/opensips-cli", line 9, in <module>
    run_console()
  File "/usr/bin/opensips-cli", line 6, in run_console
    main.main()
  File "/usr/lib/python3.6/site-packages/opensipscli/main.py", line 78, in main
    sys.exit(shell.cmdloop())
  File "/usr/lib/python3.6/site-packages/opensipscli/cli.py", line 247, in cmdloop
    ret = self.run_command(module, command, modifiers, params)
  File "/usr/lib/python3.6/site-packages/opensipscli/cli.py", line 409, in run_command
    return mod[0].__invoke__(cmd, params, modifiers)
  File "/usr/lib/python3.6/site-packages/opensipscli/module.py", line 36, in __invoke__
    return f(params, modifiers)
  File "/usr/lib/python3.6/site-packages/opensipscli/modules/database.py", line 603, in do_create
    admin_url if engine != 'sqlite' else db_url, db) < 0:
  File "/usr/lib/python3.6/site-packages/opensipscli/modules/database.py", line 627, in create_db
    if db.exists(db_name):
  File "/usr/lib/python3.6/site-packages/opensipscli/db.py", line 601, in exists
    if sqlalchemy_utils.database_exists(database_url):
  File "/usr/lib/python3.6/site-packages/opensipscli/libs/sqlalchemy_utils.py", line 92, in database_exists
    return database == ':memory:' or sqlite_file_exists(database)
  File "/usr/lib/python3.6/site-packages/opensipscli/libs/sqlalchemy_utils.py", line 64, in sqlite_file_exists
    if not os.path.isfile(database) or os.path.getsize(database) < 100:
NameError: name 'os' is not defined
```

This is a fix to this small issue