### PR TITLE
Rework Datagram Socket parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ fifo used for the reply from OpenSIPS (Default: `/tmp`)
 (Default: `http://127.0.0.1:8888/mi`).
 * `datagram_ip`: The default IP used when `datagram` `communication_type` is used (Default: `127.0.0.1`)
 * `datagram_port`: The default port used when `datagram` `communication_type` is used (Default: `8080`)
-* `datagram_unix_socket`: The default unix socket used when `datagram` `communication_type` is used (Default: `/tmp/opensips.sock`)
+* `datagram_timeout`: Timeout for Datagram Socket.
+* `datagram_buffer_size`: Buffer size for Datagram Socket.
+* `datagram_unix_socket`: Unix Domain Socket to use instead of UDP.
 
 Each module can use each of the parameters above, but can also declare their
 own. You can find in each module's documentation page the parameters that they

--- a/opensipscli/defaults.py
+++ b/opensipscli/defaults.py
@@ -67,7 +67,8 @@ DEFAULT_VALUES = {
     "url": "http://127.0.0.1:8888/mi",
     "datagram_ip": "127.0.0.1",
     "datagram_port": "8080",
-    "datagram_unix_socket": "/tmp/opensips.sock",
+    "datagram_timeout": "1",
+    "datagram_buffer_size": "65535",
 
     # database module
     "database_url": "mysql://opensips:opensipsrw@localhost",

--- a/opensipscli/version.py
+++ b/opensipscli/version.py
@@ -17,6 +17,6 @@
 ## along with this program. If not, see <http://www.gnu.org/licenses/>.
 ##
 
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
- Add UDS specific timeout.
- Add buffer size option.
- Default to UDP (do not define default socket).