### PR TITLE
Avoid requiring package python-is-python3 on Debian

### DIFF
--- a/bin/opensips-cli
+++ b/bin/opensips-cli
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from opensipscli import main
 

--- a/opensipscli/__init__.py
+++ b/opensipscli/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/args.py
+++ b/opensipscli/args.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/cli.py
+++ b/opensipscli/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/comm.py
+++ b/opensipscli/comm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/config.py
+++ b/opensipscli/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/db.py
+++ b/opensipscli/db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/defaults.py
+++ b/opensipscli/defaults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/libs/__init__.py
+++ b/opensipscli/libs/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/logger.py
+++ b/opensipscli/logger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/main.py
+++ b/opensipscli/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/module.py
+++ b/opensipscli/module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/__init__.py
+++ b/opensipscli/modules/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/database.py
+++ b/opensipscli/modules/database.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/diagnose.py
+++ b/opensipscli/modules/diagnose.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/instance.py
+++ b/opensipscli/modules/instance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/mi.py
+++ b/opensipscli/modules/mi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/tls.py
+++ b/opensipscli/modules/tls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/trace.py
+++ b/opensipscli/modules/trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/trap.py
+++ b/opensipscli/modules/trap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/user.py
+++ b/opensipscli/modules/user.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/version.py
+++ b/opensipscli/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-VERSION=$(shell python -Bc 'import sys; sys.path.append("."); from opensipscli.version import __version__; print(__version__)')
+VERSION=$(shell python3 -Bc 'import sys; sys.path.append("."); from opensipscli.version import __version__; print(__version__)')
 NAME=opensips-cli
 
 %:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).


### PR DESCRIPTION
Debian doesn't ship with anything at /usr/bin/python anymore.
To add a link from `/usr/bin/python` to `/usr/bin/python3` (and more), you are advised to install package `python-is-python3`.
But as opensips-cli is Python 3 exclusively anyway, support for Python 2.x should not be pretended.