### PR TITLE
packaging: switch to PyMySQL and support SQLAlchemy 1.4/2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The OpenSIPSCLI object can receive a set of arguments/modifiers through the
 ```
 from opensipscli import args
 ...
-args = OpenSIPSCLIArgs(debug=True)
+args = args.OpenSIPSCLIArgs(debug=True)
 opensipscli = cli.OpenSIPSCLI(args)
 ...
 ```
@@ -78,7 +78,7 @@ opensipscli = cli.OpenSIPSCLI(args)
 Custom settings can be provided through the arguments, i.e.:
 ```
 # run commands over http
-args = OpenSIPSCLIArgs(communication_type = "http",
+args = args.OpenSIPSCLIArgs(communication_type = "http",
                        url="http://127.0.0.1:8080/mi")
 ...
 ```

--- a/bin/opensips-cli
+++ b/bin/opensips-cli
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from opensipscli import main
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 #install basic components
 RUN apt-get -y update -qq && \
-    apt-get -y install git default-libmysqlclient-dev gcc
+    apt-get -y install git
 
 #add keyserver, repository
 RUN git clone https://github.com/OpenSIPS/opensips-cli.git /usr/src/opensips-cli && \
@@ -16,7 +16,7 @@ RUN git clone https://github.com/OpenSIPS/opensips-cli.git /usr/src/opensips-cli
     python3 -m pip install . && \
     cd / && rm -rf /usr/src/opensips-cli
 
-RUN apt-get purge -y git gcc && \
+RUN apt-get purge -y git && \
     apt-get autoremove -y && \
     apt-get clean
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -56,27 +56,26 @@ will vary on every supported operating system.
 
 ```
 # required OS packages
-sudo apt install python3 python3-pip python3-dev gcc default-libmysqlclient-dev \
-                 python3-mysqldb python3-sqlalchemy python3-sqlalchemy-utils \
+sudo apt install python3 python3-pip python3-pymysql python3-sqlalchemy \
                  python3-openssl
 
 # alternatively, you can build the requirements from source
-sudo pip3 install mysqlclient sqlalchemy sqlalchemy-utils pyOpenSSL
+sudo pip3 install PyMySQL sqlalchemy pyOpenSSL
 ```
 
 #### Red Hat / CentOS
 
 ```
 # required CentOS 7 packages
-sudo yum install python36 python36-pip python36-devel gcc mysql-devel \
-                 python36-mysql python36-sqlalchemy python36-pyOpenSSL
+sudo yum install python36 python36-pip python36-PyMySQL \
+                 python36-sqlalchemy python36-pyOpenSSL
 
 # required CentOS 8 packages
-sudo yum install python3 python3-pip python3-devel gcc mysql-devel \
-                 python3-mysqlclient python3-sqlalchemy python3-pyOpenSSL
+sudo yum install python3 python3-pip python3-PyMySQL \
+                 python3-sqlalchemy python3-pyOpenSSL
 
 # alternatively, you can build the requirements from source
-sudo pip3 install mysqlclient sqlalchemy sqlalchemy-utils pyOpenSSL
+sudo pip3 install PyMySQL sqlalchemy pyOpenSSL
 ```
 
 ### Download, Build & Install

--- a/docs/modules/database.md
+++ b/docs/modules/database.md
@@ -41,10 +41,10 @@ are using the OpenSIPS source tree.  Default: `/usr/share/opensips`
 (administrator) access level which will be used to create/drop databases, as
 well as to create or ensure access for the non-privileged DB access user
 provided via `database_url`.  The URL combines schema, username, password, host
-and port.  Default: `mysql://root@localhost`.
+and port.  Default: `mysql+pymysql://root@localhost`.
 * `database_url` (optional) - the connection string to the database.  A good practice
 would be to use a non-administrator access user for this URL.  Default:
-`mysql://opensips:opensipsrw@localhost`.
+`mysql+pymysql://opensips:opensipsrw@localhost`.
 * `database_name` (optional) - the name of the database.  Modules may be separately added
 to this database if you choose not to install all of them.  Default: `opensips`.
 * `database_modules` (optional) - accepts the `ALL` keyword that indicates all the
@@ -68,7 +68,7 @@ Consider the following configuration file:
 database_modules: ALL
 
 #database_admin_url: postgresql://root@localhost
-database_admin_url: mysql://root@localhost
+database_admin_url: mysql+pymysql://root@localhost
 ```
 
 The following command will create the `opensips` database and all possible

--- a/docs/modules/database.md
+++ b/docs/modules/database.md
@@ -41,10 +41,10 @@ are using the OpenSIPS source tree.  Default: `/usr/share/opensips`
 (administrator) access level which will be used to create/drop databases, as
 well as to create or ensure access for the non-privileged DB access user
 provided via `database_url`.  The URL combines schema, username, password, host
-and port.  Default: `mysql+pymysql://root@localhost`.
+and port.  Default: `mysql://root@localhost`.
 * `database_url` (optional) - the connection string to the database.  A good practice
 would be to use a non-administrator access user for this URL.  Default:
-`mysql+pymysql://opensips:opensipsrw@localhost`.
+`mysql://opensips:opensipsrw@localhost`.
 * `database_name` (optional) - the name of the database.  Modules may be separately added
 to this database if you choose not to install all of them.  Default: `opensips`.
 * `database_modules` (optional) - accepts the `ALL` keyword that indicates all the
@@ -68,7 +68,7 @@ Consider the following configuration file:
 database_modules: ALL
 
 #database_admin_url: postgresql://root@localhost
-database_admin_url: mysql+pymysql://root@localhost
+database_admin_url: mysql://root@localhost
 ```
 
 The following command will create the `opensips` database and all possible

--- a/docs/modules/database.md
+++ b/docs/modules/database.md
@@ -132,8 +132,10 @@ opensips-cli -o database_schema_path=~/src/opensips-3.1/scripts \
 
 ## Dependencies
 
-* [sqlalchemy and sqlalchemy_utils](https://www.sqlalchemy.org/) - used to
-abstract the SQL database regardless of the backend used
+* [sqlalchemy](https://www.sqlalchemy.org/) - used to abstract the SQL
+database regardless of the backend used
+* [PyMySQL](https://github.com/PyMySQL/PyMySQL) - pure-Python MySQL/MariaDB
+driver used by SQLAlchemy when connecting to MySQL backends
 
 ## Limitations
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -53,8 +53,8 @@ opensips-cli -x user delete username@domain.com
 
 ## Dependencies
 
-* [sqlalchemy and sqlalchemy_utils](https://www.sqlalchemy.org/) - used to
-abstract the database manipulation, regardless of the backend used
+* [sqlalchemy](https://www.sqlalchemy.org/) - used to abstract the database
+manipulation, regardless of the backend used
 
 ## Limitations
 

--- a/opensipscli/__init__.py
+++ b/opensipscli/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/args.py
+++ b/opensipscli/args.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/cli.py
+++ b/opensipscli/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/comm.py
+++ b/opensipscli/comm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/config.py
+++ b/opensipscli/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/db.py
+++ b/opensipscli/db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/db.py
+++ b/opensipscli/db.py
@@ -27,6 +27,7 @@ try:
     try:
         from sqlalchemy.orm import declarative_base  # SA 1.4+
     except ImportError:
+        # keep this for Debian Bullseye, which still has SA 1.3 in stable
         from sqlalchemy.ext.declarative import declarative_base  # SA 1.3
     from sqlalchemy.orm import sessionmaker, deferred
 

--- a/opensipscli/db.py
+++ b/opensipscli/db.py
@@ -24,7 +24,11 @@ import re
 try:
     import sqlalchemy
     from sqlalchemy import Column, Date, Integer, String, Boolean, text
-    from sqlalchemy.orm import declarative_base, sessionmaker, deferred
+    try:
+        from sqlalchemy.orm import declarative_base  # SA 1.4+
+    except ImportError:
+        from sqlalchemy.ext.declarative import declarative_base  # SA 1.3
+    from sqlalchemy.orm import sessionmaker, deferred
 
     # for now, we use our own make_url(), since Alchemy API is highly unstable
     #  (https://github.com/OpenSIPS/opensips-cli/issues/85)
@@ -32,12 +36,11 @@ try:
 
     sqlalchemy_available = True
     logger.debug("SQLAlchemy version: %s", sqlalchemy.__version__)
-    try:
-        import sqlalchemy_utils
-    except ImportError:
-        logger.debug("using embedded implementation of SQLAlchemy_Utils")
-        # copied from SQLAlchemy_utils repository
-        from opensipscli.libs import sqlalchemy_utils
+    # always use the vendored shim — the system sqlalchemy-utils package
+    # varies a lot across distros (0.36.x ships broken database_exists for
+    # PostgreSQL on Bullseye; 0.41.x is required for SA 2.0); the shim is
+    # tested against SA 1.3–2.0 and behaves consistently
+    from opensipscli.libs import sqlalchemy_utils
 except ImportError:
     logger.info("sqlalchemy not available!")
     sqlalchemy_available = False

--- a/opensipscli/db.py
+++ b/opensipscli/db.py
@@ -23,16 +23,15 @@ import re
 
 try:
     import sqlalchemy
-    from sqlalchemy.ext.declarative import declarative_base
-    from sqlalchemy import Column, Date, Integer, String, Boolean
-    from sqlalchemy.orm import sessionmaker, deferred
+    from sqlalchemy import Column, Date, Integer, String, Boolean, text
+    from sqlalchemy.orm import declarative_base, sessionmaker, deferred
 
     # for now, we use our own make_url(), since Alchemy API is highly unstable
     #  (https://github.com/OpenSIPS/opensips-cli/issues/85)
     #from sqlalchemy.engine.url import make_url
 
     sqlalchemy_available = True
-    logger.debug("SQLAlchemy version: ", sqlalchemy.__version__)
+    logger.debug("SQLAlchemy version: %s", sqlalchemy.__version__)
     try:
         import sqlalchemy_utils
     except ImportError:
@@ -205,14 +204,10 @@ class osdb(object):
 
 	    # TODO: do this only for SQLAlchemy
         try:
-            if self.dialect == "postgresql":
-                self.__engine = sqlalchemy.create_engine(db_url, isolation_level='AUTOCOMMIT')
-            else:
-                self.__engine = sqlalchemy.create_engine(db_url)
+            self.__engine = sqlalchemy.create_engine(db_url, isolation_level='AUTOCOMMIT')
 
             logger.debug("connecting to %s", db_url)
-            self.__conn = self.__engine.connect().\
-                    execution_options(autocommit=True)
+            self.__conn = self.__engine.connect()
             # connect the Session object to our engine
             self.Session.configure(bind=self.__engine)
             # instantiate the Session object
@@ -266,7 +261,7 @@ class osdb(object):
             msg += " and password '********'"
         msg += " on database '{}'".format(self.db_name)
         try:
-            result = self.__conn.execute(sqlcmd)
+            result = self.__conn.execute(text(sqlcmd))
             if result:
                 logger.info( "{} was successful".format(msg))
         except:
@@ -296,7 +291,7 @@ class osdb(object):
                     self.session = self.Session()
                     logger.debug("connected to database URL '%s'", self.db_url)
             elif self.dialect != "sqlite":
-                self.__conn.execute("USE {}".format(self.db_name))
+                self.__conn.execute(text("USE {}".format(self.db_name)))
         except Exception as e:
             logger.error("failed to connect to %s", self.db_url)
             logger.error(e)
@@ -319,15 +314,13 @@ class osdb(object):
 
         # all good - it's time to create the database
         if self.dialect == "postgresql":
-            self.__conn.connection.connection.set_isolation_level(0)
             try:
-                self.__conn.execute("CREATE DATABASE {}".format(self.db_name))
-                self.__conn.connection.connection.set_isolation_level(1)
+                self.__conn.execute(text("CREATE DATABASE {}".format(self.db_name)))
             except sqlalchemy.exc.OperationalError as se:
                 logger.error("cannot create database: {}!".format(se))
                 return False
         elif self.dialect != "sqlite":
-            self.__conn.execute("CREATE DATABASE {}".format(self.db_name))
+            self.__conn.execute(text("CREATE DATABASE {}".format(self.db_name)))
 
         logger.debug("success")
         return True
@@ -344,11 +337,11 @@ class osdb(object):
             logger.error("database URL does not include a password")
             return False
 
-        if url.drivername.lower() == "mysql":
+        if url.drivername.lower().split('+')[0] == "mysql":
             sqlcmd = "CREATE USER IF NOT EXISTS '{}' IDENTIFIED BY '{}'".format(
                         url.username, url.password)
             try:
-                result = self.__conn.execute(sqlcmd)
+                result = self.__conn.execute(text(sqlcmd))
                 if result:
                     logger.info("created user '%s'", url.username)
             except:
@@ -368,7 +361,7 @@ class osdb(object):
                 sqlcmd = "SET PASSWORD FOR '{}' = PASSWORD('{}')".format(
                             url.username, url.password)
                 try:
-                    result = self.__conn.execute(sqlcmd)
+                    result = self.__conn.execute(text(sqlcmd))
                     if result:
                         logger.info("set password '%s%s%s' for '%s' (MariaDB)",
                             url.password[0] if len(url.password) >= 1 else '',
@@ -381,7 +374,7 @@ class osdb(object):
                             # syntax error!  OK, now try Oracle MySQL syntax
                             sqlcmd = "ALTER USER '{}' IDENTIFIED BY '{}'".format(
                                         url.username, url.password)
-                            result = self.__conn.execute(sqlcmd)
+                            result = self.__conn.execute(text(sqlcmd))
                             if result:
                                 logger.info("set password '%s%s%s' for '%s' (MySQL)",
                                     url.password[0] if len(url.password) >= 1 else '',
@@ -397,7 +390,7 @@ class osdb(object):
 
             sqlcmd = "GRANT ALL ON {}.* TO '{}'".format(self.db_name, url.username)
             try:
-                result = self.__conn.execute(sqlcmd)
+                result = self.__conn.execute(text(sqlcmd))
                 if result:
                     logger.info("granted access to user '%s' on DB '%s'",
                                 url.username, self.db_name)
@@ -408,13 +401,13 @@ class osdb(object):
 
             sqlcmd = "FLUSH PRIVILEGES"
             try:
-                result = self.__conn.execute(sqlcmd)
+                result = self.__conn.execute(text(sqlcmd))
                 logger.info("flushed privileges")
             except:
                 logger.exception("failed to flush privileges")
                 return False
 
-        elif url.drivername.lower() == "postgresql":
+        elif url.drivername.lower().split('+')[0] == "postgresql":
             if not self.exists_role(url.username):
                 logger.info("creating role %s", url.username)
                 if not self.create_role(url.username, url.password):
@@ -427,7 +420,7 @@ class osdb(object):
             logger.info(sqlcmd)
 
             try:
-                result = self.__conn.execute(sqlcmd)
+                result = self.__conn.execute(text(sqlcmd))
                 if result:
                     logger.debug("... OK")
             except:
@@ -459,7 +452,7 @@ class osdb(object):
         logger.info(sqlcmd)
 
         try:
-            result = self.__conn.execute(sqlcmd)
+            result = self.__conn.execute(text(sqlcmd))
             if result:
                 logger.info("role '{}' with options '{}' created".
                     format(role_name, role_options))
@@ -481,7 +474,7 @@ class osdb(object):
         where_str = self.get_where(filter_keys)
         statement = "DELETE FROM {}{}".format(table, where_str)
         try:
-            self.__conn.execute(statement)
+            self.__conn.execute(text(statement))
         except sqlalchemy.exc.SQLAlchemyError as ex:
             logger.error("cannot execute query: {}".format(statement))
             logger.error(ex)
@@ -535,7 +528,7 @@ class osdb(object):
 
         sqlcmd = "DROP ROLE IF EXISTS {}".format(role_name)
         try:
-            result = self.__conn.execute(sqlcmd)
+            result = self.__conn.execute(text(sqlcmd))
             if result:
                 logger.debug("Role '%s' dropped", role_name)
         except:
@@ -572,7 +565,7 @@ class osdb(object):
                     # DROP/CREATE PROCEDURE statements seem to only work separately
                     sql = re.sub(r'DROP PROCEDURE .*\n', '', sql)
 
-                    self.__conn.execute(sql)
+                    self.__conn.execute(text(sql))
                 except sqlalchemy.exc.IntegrityError as ie:
                     raise osdbError("cannot deploy {} file: {}".
                             format(sql_file, ie)) from None
@@ -582,7 +575,7 @@ class osdb(object):
                     if not sql:
                         continue
                     try:
-                        self.__conn.execute(sql)
+                        self.__conn.execute(text(sql))
                     except sqlalchemy.exc.IntegrityError as ie:
                         raise osdbModuleAlreadyExistsError(
                             "cannot deploy {} file: {}".format(sql_file, ie)) from None
@@ -665,7 +658,7 @@ class osdb(object):
                 table,
                 where_str)
         try:
-            result = self.__conn.execute(statement)
+            result = self.__conn.execute(text(statement))
         except sqlalchemy.exc.SQLAlchemyError as ex:
             logger.error("cannot execute query: {}".format(statement))
             logger.error(ex)
@@ -676,7 +669,7 @@ class osdb(object):
         """
         extract database dialect from an url
         """
-        return url.split('://')[0]
+        return url.split('://')[0].split('+')[0]
 
     def get_where(self, filter_keys):
         """
@@ -738,7 +731,7 @@ class osdb(object):
         logger.info(sqlcmd)
 
         try:
-            self.__conn.execute(sqlcmd)
+            self.__conn.execute(text(sqlcmd))
         except Exception as e:
             logger.exception(e)
             logger.error("failed to grant '%s' '%s' to '%s'", privs, on_statement, role_name)
@@ -767,6 +760,11 @@ class osdb(object):
             sqlalchemy.create_engine('{}://'.format(dialect))
         except sqlalchemy.exc.NoSuchModuleError:
             return False
+        except Exception:
+            # dialect is known to SQLAlchemy but its default DBAPI is not
+            # installed (e.g. MySQLdb when only PyMySQL is available);
+            # a compatible driver is still usable via the +driver URL syntax
+            pass
         return True
 
     def insert(self, table, keys):
@@ -781,14 +779,14 @@ class osdb(object):
         for v in keys.values():
             values += ", "
             if type(v) == int:
-                values += v
+                values += str(v)
             else:
                 values += "'{}'".format(
                         v.translate(str.maketrans({'\'': '\\\''})))
         statement = "INSERT INTO {} ({}) VALUES ({})".format(
                 table, ", ".join(keys.keys()), values[2:])
         try:
-            result = self.__conn.execute(statement)
+            result = self.__conn.execute(text(statement))
         except sqlalchemy.exc.SQLAlchemyError as ex:
             logger.error("cannot execute query: {}".format(statement))
             logger.error(ex)
@@ -873,7 +871,7 @@ class osdb(object):
         for k, v in update_keys.items():
             update_str += ", {} = ".format(k)
             if type(v) == int:
-                update_str += v
+                update_str += str(v)
             else:
                 update_str += "'{}'".format(
                         v.translate(str.maketrans({'\'': '\\\''})))
@@ -881,7 +879,7 @@ class osdb(object):
         statement = "UPDATE {} SET {}{}".format(table,
                 update_str[2:], where_str)
         try:
-            result = self.__conn.execute(statement)
+            result = self.__conn.execute(text(statement))
         except sqlalchemy.exc.SQLAlchemyError as ex:
             logger.error("cannot execute query: {}".format(statement))
             logger.error(ex)
@@ -961,8 +959,8 @@ class osdb(object):
 
     @staticmethod
     def get_url_driver(url, capitalize=False):
+        driver = make_url(url).drivername.lower().split('+')[0]
         if capitalize:
-            driver = make_url(url).drivername.lower()
             capitalized = {
                 'mysql': 'MySQL',
                 'postgresql': 'PostgreSQL',
@@ -971,7 +969,7 @@ class osdb(object):
                 }
             return capitalized.get(driver, driver.capitalize())
         else:
-            return make_url(url).drivername.lower()
+            return driver
 
 
     @staticmethod

--- a/opensipscli/db.py
+++ b/opensipscli/db.py
@@ -42,6 +42,8 @@ try:
     # PostgreSQL on Bullseye; 0.41.x is required for SA 2.0); the shim is
     # tested against SA 1.3–2.0 and behaves consistently
     from opensipscli.libs import sqlalchemy_utils
+    import pymysql
+    pymysql.install_as_MySQLdb()
 except ImportError:
     logger.info("sqlalchemy not available!")
     sqlalchemy_available = False

--- a/opensipscli/defaults.py
+++ b/opensipscli/defaults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/defaults.py
+++ b/opensipscli/defaults.py
@@ -71,7 +71,7 @@ DEFAULT_VALUES = {
     "datagram_buffer_size": "65535",
 
     # database module
-    "database_url": "mysql://opensips:opensipsrw@localhost",
+    "database_url": "mysql+pymysql://opensips:opensipsrw@localhost",
     "database_name": "opensips",
     "database_schema_path": "/usr/share/opensips",
 

--- a/opensipscli/defaults.py
+++ b/opensipscli/defaults.py
@@ -71,7 +71,7 @@ DEFAULT_VALUES = {
     "datagram_buffer_size": "65535",
 
     # database module
-    "database_url": "mysql+pymysql://opensips:opensipsrw@localhost",
+    "database_url": "mysql://opensips:opensipsrw@localhost",
     "database_name": "opensips",
     "database_schema_path": "/usr/share/opensips",
 

--- a/opensipscli/libs/__init__.py
+++ b/opensipscli/libs/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/libs/sqlalchemy_utils.py
+++ b/opensipscli/libs/sqlalchemy_utils.py
@@ -15,230 +15,133 @@
 ## * The names of the contributors may not be used to endorse or promote products
 ##   derived from this software without specific prior written permission.
 ##
-## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-## ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-## WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-## DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT,
-## INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-## BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-## DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-## OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+## OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+## WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+## OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ## ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ##
-## Copied from https://github.com/kvesteri/sqlalchemy-utils/blob/2e8ee0093f4a33a5c7479bc9aaf16d7863a74a16/sqlalchemy_utils/functions/database.py
+## Adapted from https://github.com/kvesteri/sqlalchemy-utils
+## Updated for SQLAlchemy 1.4/2.0 compatibility (engine.execute removed).
 ## Please check LICENSE
 
 from copy import copy
 
 import os
 import sqlalchemy as sa
-from sqlalchemy.engine.url import make_url
+from sqlalchemy import text
 from sqlalchemy.exc import OperationalError, ProgrammingError
-from sqlalchemy.engine.interfaces import Dialect
-from sqlalchemy.orm.session import object_session
-from sqlalchemy.orm.exc import UnmappedInstanceError
+
+try:
+    from sqlalchemy import make_url
+except ImportError:
+    from sqlalchemy.engine.url import make_url
+
+
+def _get_scalar(engine, sql):
+    with engine.connect() as conn:
+        result = conn.execute(text(sql))
+        value = result.scalar()
+    engine.dispose()
+    return value
+
 
 def database_exists(url):
-    """Check if a database exists.
-    :param url: A SQLAlchemy engine URL.
-    Performs backend-specific testing to quickly determine if a database
-    exists on the server. ::
-        database_exists('postgresql://postgres@localhost/name')  #=> False
-        create_database('postgresql://postgres@localhost/name')
-        database_exists('postgresql://postgres@localhost/name')  #=> True
-    Supports checking against a constructed URL as well. ::
-        engine = create_engine('postgresql://postgres@localhost/name')
-        database_exists(engine.url)  #=> False
-        create_database(engine.url)
-        database_exists(engine.url)  #=> True
-    """
-
-    def get_scalar_result(engine, sql):
-        result_proxy = engine.execute(sql)
-        result = result_proxy.scalar()
-        result_proxy.close()
-        engine.dispose()
-        return result
+    """Check if a database exists."""
 
     def sqlite_file_exists(database):
         if not os.path.isfile(database) or os.path.getsize(database) < 100:
             return False
-
         with open(database, 'rb') as f:
             header = f.read(100)
-
         return header[:16] == b'SQLite format 3\x00'
 
     url = copy(make_url(url))
-    if hasattr(url, "_replace"):
+    try:
         database = url.database
-        url = url._replace(database=None)
-    else:
+        url = url.set(database=None)
+    except AttributeError:
         database, url.database = url.database, None
 
-    engine = sa.create_engine(url)
-
-    if engine.dialect.name == 'postgresql':
-        text = "SELECT 1 FROM pg_database WHERE datname='%s'" % database
-        return bool(get_scalar_result(engine, text))
-
-    elif engine.dialect.name == 'mysql':
-        text = ("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA "
-                "WHERE SCHEMA_NAME = '%s'" % database)
-        return bool(get_scalar_result(engine, text))
-
-    elif engine.dialect.name == 'sqlite':
+    if url.get_dialect().name == 'sqlite':
         if database:
             return database == ':memory:' or sqlite_file_exists(database)
-        else:
-            # The default SQLAlchemy database is in memory,
-            # and :memory is not required, thus we should support that use-case
-            return True
+        return True
+
+    engine = sa.create_engine(url, isolation_level='AUTOCOMMIT')
+
+    if engine.dialect.name == 'postgresql':
+        sql = "SELECT 1 FROM pg_database WHERE datname='%s'" % database
+        return bool(_get_scalar(engine, sql))
+
+    elif engine.dialect.name == 'mysql':
+        sql = ("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA "
+               "WHERE SCHEMA_NAME = '%s'" % database)
+        return bool(_get_scalar(engine, sql))
 
     else:
-        engine.dispose()
-        engine = None
-        text = 'SELECT 1'
         try:
-            if hasattr(url, "_replace"):
-                url = url._replace(database=database)
-            else:
+            url = copy(make_url(str(url)))
+            try:
+                url = url.set(database=database)
+            except AttributeError:
                 url.database = database
-
-            engine = sa.create_engine(url)
-            result = engine.execute(text)
-            result.close()
+            engine2 = sa.create_engine(url)
+            with engine2.connect() as conn:
+                conn.execute(text('SELECT 1'))
+            engine2.dispose()
             return True
-
         except (ProgrammingError, OperationalError):
             return False
-        finally:
-            if engine is not None:
-                engine.dispose()
 
-def get_bind(obj):
-    """
-    Return the bind for given SQLAlchemy Engine / Connection / declarative
-    model object.
-    :param obj: SQLAlchemy Engine / Connection / declarative model object
-    ::
-        from sqlalchemy_utils import get_bind
-        get_bind(session)  # Connection object
-        get_bind(user)
-    """
-    if hasattr(obj, 'bind'):
-        conn = obj.bind
-    else:
-        try:
-            conn = object_session(obj).bind
-        except UnmappedInstanceError:
-            conn = obj
-
-    if not hasattr(conn, 'execute'):
-        raise TypeError(
-            'This method accepts only Session, Engine, Connection and '
-            'declarative model objects.'
-        )
-    return conn
-
-def quote(mixed, ident):
-    """
-    Conditionally quote an identifier.
-    ::
-        from sqlalchemy_utils import quote
-        engine = create_engine('sqlite:///:memory:')
-        quote(engine, 'order')
-        # '"order"'
-        quote(engine, 'some_other_identifier')
-        # 'some_other_identifier'
-    :param mixed: SQLAlchemy Session / Connection / Engine / Dialect object.
-    :param ident: identifier to conditionally quote
-    """
-    if isinstance(mixed, Dialect):
-        dialect = mixed
-    else:
-        dialect = get_bind(mixed).dialect
-    return dialect.preparer(dialect).quote(ident)
 
 def drop_database(url):
-    """Issue the appropriate DROP DATABASE statement.
-    :param url: A SQLAlchemy engine URL.
-    Works similar to the :ref:`create_database` method in that both url text
-    and a constructed url are accepted. ::
-        drop_database('postgresql://postgres@localhost/name')
-        drop_database(engine.url)
-    """
+    """Issue the appropriate DROP DATABASE statement."""
 
     url = copy(make_url(url))
-
     database = url.database
 
     if url.drivername.startswith('postgres'):
-        if hasattr(url, "set"):
+        try:
             url = url.set(database='postgres')
-        else:
+        except AttributeError:
             url.database = 'postgres'
-
     elif url.drivername.startswith('mssql'):
-        if hasattr(url, "set"):
+        try:
             url = url.set(database='master')
-        else:
+        except AttributeError:
             url.database = 'master'
-
     elif not url.drivername.startswith('sqlite'):
-        if hasattr(url, "_replace"):
-            url = url._replace(database=None)
-        else:
+        try:
+            url = url.set(database=None)
+        except AttributeError:
             url.database = None
 
-    if url.drivername == 'mssql+pyodbc':
-        engine = sa.create_engine(url, connect_args={'autocommit': True})
-    elif url.drivername == 'postgresql+pg8000':
-        engine = sa.create_engine(url, isolation_level='AUTOCOMMIT')
-    else:
-        engine = sa.create_engine(url)
-    conn_resource = None
+    engine = sa.create_engine(url, isolation_level='AUTOCOMMIT')
 
     if engine.dialect.name == 'sqlite' and database != ':memory:':
         if database:
             os.remove(database)
+        engine.dispose()
+        return
 
-    elif (
-                engine.dialect.name == 'postgresql' and
-                engine.driver in {'psycopg2', 'psycopg2cffi'}
-    ):
-        if engine.driver == 'psycopg2':
-            from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-            connection = engine.connect()
-            connection.connection.set_isolation_level(
-                ISOLATION_LEVEL_AUTOCOMMIT
-            )
-        else:
-            connection = engine.connect()
-            connection.connection.set_session(autocommit=True)
+    with engine.connect() as conn:
+        if engine.dialect.name == 'postgresql':
+            pid_column = 'pid'
+            terminate_sql = """
+            SELECT pg_terminate_backend(pg_stat_activity.%(pid)s)
+            FROM pg_stat_activity
+            WHERE pg_stat_activity.datname = '%(db)s'
+              AND %(pid)s <> pg_backend_pid()
+            """ % {'pid': pid_column, 'db': database}
+            conn.execute(text(terminate_sql))
 
-        # Disconnect all users from the database we are dropping.
-        version = connection.dialect.server_version_info
-        pid_column = (
-            'pid' if (version >= (9, 2)) else 'procpid'
-        )
-        text = '''
-        SELECT pg_terminate_backend(pg_stat_activity.%(pid_column)s)
-        FROM pg_stat_activity
-        WHERE pg_stat_activity.datname = '%(database)s'
-          AND %(pid_column)s <> pg_backend_pid();
-        ''' % {'pid_column': pid_column, 'database': database}
-        connection.execute(text)
+        quoted = engine.dialect.preparer(engine.dialect).quote(database)
+        conn.execute(text('DROP DATABASE {}'.format(quoted)))
 
-        # Drop the database.
-        text = 'DROP DATABASE {0}'.format(quote(connection, database))
-        connection.execute(text)
-        conn_resource = connection
-    else:
-        text = 'DROP DATABASE {0}'.format(quote(engine, database))
-        conn_resource = engine.execute(text)
-
-    if conn_resource is not None:
-        conn_resource.close()
     engine.dispose()

--- a/opensipscli/libs/sqlalchemy_utils.py
+++ b/opensipscli/libs/sqlalchemy_utils.py
@@ -73,6 +73,20 @@ def database_exists(url):
             return database == ':memory:' or sqlite_file_exists(database)
         return True
 
+    # connecting without a database is unreliable: psycopg2 always requires
+    # a target DB, and some PyMySQL versions ignore database=None — point at
+    # a system DB that is always present instead
+    if url.get_dialect().name == 'postgresql':
+        try:
+            url = url.set(database='postgres')
+        except AttributeError:
+            url.database = 'postgres'
+    elif url.get_dialect().name == 'mysql':
+        try:
+            url = url.set(database='information_schema')
+        except AttributeError:
+            url.database = 'information_schema'
+
     engine = sa.create_engine(url, isolation_level='AUTOCOMMIT')
 
     if engine.dialect.name == 'postgresql':
@@ -116,6 +130,11 @@ def drop_database(url):
             url = url.set(database='master')
         except AttributeError:
             url.database = 'master'
+    elif url.drivername.startswith('mysql'):
+        try:
+            url = url.set(database='information_schema')
+        except AttributeError:
+            url.database = 'information_schema'
     elif not url.drivername.startswith('sqlite'):
         try:
             url = url.set(database=None)

--- a/opensipscli/logger.py
+++ b/opensipscli/logger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/main.py
+++ b/opensipscli/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/module.py
+++ b/opensipscli/module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/__init__.py
+++ b/opensipscli/modules/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/database.py
+++ b/opensipscli/modules/database.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/database.py
+++ b/opensipscli/modules/database.py
@@ -631,8 +631,14 @@ class database(Module):
         if not engine:
             return None
 
-        # make sure to inherit the 'database_admin_url' engine + host
-        db_url = osdb.set_url_driver(cfg.get("database_url"), engine)
+        # inherit the full driver spec (e.g. mysql+pymysql) from the admin URL
+        # so that a +driver suffix set by the user is not silently dropped
+        if cfg.exists('database_admin_url'):
+            full_driver = cfg.get('database_admin_url').split('://')[0]
+        else:
+            full_driver = cfg.get('database_url').split('://')[0]
+
+        db_url = osdb.set_url_driver(cfg.get("database_url"), full_driver)
         db_url = osdb.set_url_host(db_url, osdb.get_db_host())
 
         logger.debug("DB URL: '{}'".format(db_url))

--- a/opensipscli/modules/diagnose.py
+++ b/opensipscli/modules/diagnose.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/instance.py
+++ b/opensipscli/modules/instance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/mi.py
+++ b/opensipscli/modules/mi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/tls.py
+++ b/opensipscli/modules/tls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/trace.py
+++ b/opensipscli/modules/trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/trap.py
+++ b/opensipscli/modules/trap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/modules/user.py
+++ b/opensipscli/modules/user.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/opensipscli/version.py
+++ b/opensipscli/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/OpenSIPS/opensips-cli
 Package: opensips-cli
 Architecture: all
 Multi-Arch: foreign
-Depends: python3, ${misc:Depends}, ${python3:Depends}, python3-sqlalchemy, python3-openssl, python3-pymysql, python3-opensips
+Depends: python3, ${misc:Depends}, ${python3:Depends}, python3-sqlalchemy (>= 1.3.16), python3-openssl, python3-pymysql, python3-opensips
 Description: Interactive command-line tool for OpenSIPS 3.0+
  This package contains the OpenSIPS CLI tool, an interactive command line tool
  that can be used to control and monitor OpenSIPS 3.0+ servers.

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -2,14 +2,14 @@ Source: opensips-cli
 Section: python
 Priority: optional
 Maintainer: Razvan Crainea <razvan@opensips.org>
-Build-Depends: debhelper (>= 9), dh-python, python3-setuptools, python3-dev, default-libmysqlclient-dev | libmysqlclient-dev, python3-sqlalchemy, python3-opensips
+Build-Depends: debhelper (>= 9), dh-python, python3-setuptools, python3-dev, python3-sqlalchemy, python3-opensips
 Standards-Version: 3.9.8
 Homepage: https://github.com/OpenSIPS/opensips-cli
 
 Package: opensips-cli
 Architecture: all
 Multi-Arch: foreign
-Depends: python3, ${misc:Depends}, ${python3:Depends}, python3-sqlalchemy, python3-sqlalchemy-utils, python3-openssl, python3-mysqldb, python3-pymysql, python3-opensips
+Depends: python3, ${misc:Depends}, ${python3:Depends}, python3-sqlalchemy, python3-sqlalchemy-utils, python3-openssl, python3-pymysql, python3-opensips
 Description: Interactive command-line tool for OpenSIPS 3.0+
  This package contains the OpenSIPS CLI tool, an interactive command line tool
  that can be used to control and monitor OpenSIPS 3.0+ servers.

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/OpenSIPS/opensips-cli
 Package: opensips-cli
 Architecture: all
 Multi-Arch: foreign
-Depends: python3, ${misc:Depends}, ${python3:Depends}, python3-sqlalchemy, python3-sqlalchemy-utils, python3-openssl, python3-pymysql, python3-opensips
+Depends: python3, ${misc:Depends}, ${python3:Depends}, python3-sqlalchemy, python3-openssl, python3-pymysql, python3-opensips
 Description: Interactive command-line tool for OpenSIPS 3.0+
  This package contains the OpenSIPS CLI tool, an interactive command line tool
  that can be used to control and monitor OpenSIPS 3.0+ servers.

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-VERSION=$(shell python -Bc 'import sys; sys.path.append("."); from opensipscli.version import __version__; print(__version__)')
+VERSION=$(shell python3 -Bc 'import sys; sys.path.append("."); from opensipscli.version import __version__; print(__version__)')
 NAME=opensips-cli
 
 %:

--- a/packaging/redhat_fedora/opensips-cli.spec
+++ b/packaging/redhat_fedora/opensips-cli.spec
@@ -12,7 +12,6 @@ BuildArch: noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-rpm-macros
-BuildRequires:  mysql-devel
 BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 AutoReqProv: no
@@ -20,11 +19,11 @@ AutoReqProv: no
 Requires: python3
 %if 0%{?rhel} == 7
 Requires: python36-sqlalchemy
-Requires: python36-mysql
+Requires: python36-PyMySQL
 Requires: python36-pyOpenSSL
 %else
 Requires: python3-sqlalchemy
-Requires: python3-mysqlclient
+Requires: python3-PyMySQL
 Requires: python3-pyOpenSSL
 %endif
 Requires: python3-opensips

--- a/packaging/redhat_fedora/opensips-cli.spec
+++ b/packaging/redhat_fedora/opensips-cli.spec
@@ -18,11 +18,11 @@ AutoReqProv: no
 
 Requires: python3
 %if 0%{?rhel} == 7
-Requires: python36-sqlalchemy
+Requires: python36-sqlalchemy >= 1.3.16
 Requires: python36-PyMySQL
 Requires: python36-pyOpenSSL
 %else
-Requires: python3-sqlalchemy
+Requires: python3-sqlalchemy >= 1.3.16
 Requires: python3-PyMySQL
 Requires: python3-pyOpenSSL
 %endif

--- a/packaging/redhat_fedora/opensips-cli.spec
+++ b/packaging/redhat_fedora/opensips-cli.spec
@@ -43,7 +43,7 @@ loaded.
 Among others, the following modules are available: Digest Authentication, CPL
 scripts, Instant Messaging, MySQL support, Presence Agent, Radius
 Authentication, Record Routing, SMS Gateway, Jabber/XMPP Gateway, Transaction
-Module, Registrar and User Location, Load Balaning/Dispatching/LCR,
+Module, Registrar and User Location, Load Balancing/Dispatching/LCR,
 XMLRPC Interface.
 
 %prep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "opensips",
     "PyMySQL",
     "sqlalchemy>=1.4",
-    "sqlalchemy-utils",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 dependencies = [
     "opensips",
     "PyMySQL",
-    "sqlalchemy>=1.3.3",
+    "sqlalchemy>=1.3.16",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 dependencies = [
     "opensips",
     "PyMySQL",
-    "sqlalchemy>=1.4",
+    "sqlalchemy>=1.3.3",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ maintainers = [
 ]
 dependencies = [
     "opensips",
-    "mysqlclient<1.4.0rc1",
-    "sqlalchemy>=1.3.3,<2",
+    "PyMySQL",
+    "sqlalchemy>=1.4",
     "sqlalchemy-utils",
 ]
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ## This file is part of OpenSIPS CLI
 ## (see https://github.com/OpenSIPS/opensips-cli).

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "opensips",
         "PyMySQL",
         "sqlalchemy>=1.4",
-        "sqlalchemy-utils",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         "opensips",
         "PyMySQL",
-        "sqlalchemy>=1.4",
+        "sqlalchemy>=1.3.3",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
     packages=find_packages(include=("opensipscli", "opensipscli.*")),
     install_requires=[
         "opensips",
-        "mysqlclient<1.4.0rc1",
-        "sqlalchemy>=1.3.3,<2",
+        "PyMySQL",
+        "sqlalchemy>=1.4",
         "sqlalchemy-utils",
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         "opensips",
         "PyMySQL",
-        "sqlalchemy>=1.3.3",
+        "sqlalchemy>=1.3.16",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/test/alltests.py
+++ b/test/alltests.py
@@ -26,17 +26,17 @@ class OpenSIPSCLIUnitTests(unittest.TestCase):
         assert repr(u) == 'x://user:***@host:12/db'
         assert str(u) == 'x://user:pass@host:12/db'
 
-        u = make_url('mysql+pymysql://opensips:opensipsrw@localhost/opensips')
-        assert repr(u) == 'mysql+pymysql://opensips:***@localhost/opensips'
-        assert str(u) == 'mysql+pymysql://opensips:opensipsrw@localhost/opensips'
+        u = make_url('mysql://opensips:opensipsrw@localhost/opensips')
+        assert repr(u) == 'mysql://opensips:***@localhost/opensips'
+        assert str(u) == 'mysql://opensips:opensipsrw@localhost/opensips'
 
-        u = make_url('mysql+pymysql://opensips:opensipsrw@localhost')
-        assert repr(u) == 'mysql+pymysql://opensips:***@localhost'
-        assert str(u) == 'mysql+pymysql://opensips:opensipsrw@localhost'
+        u = make_url('mysql://opensips:opensipsrw@localhost')
+        assert repr(u) == 'mysql://opensips:***@localhost'
+        assert str(u) == 'mysql://opensips:opensipsrw@localhost'
 
-        u = make_url('mysql+pymysql://root@localhost')
-        assert repr(u) == 'mysql+pymysql://root@localhost'
-        assert str(u) == 'mysql+pymysql://root@localhost'
+        u = make_url('mysql://root@localhost')
+        assert repr(u) == 'mysql://root@localhost'
+        assert str(u) == 'mysql://root@localhost'
 
 
 if __name__ == "__main__":

--- a/test/alltests.py
+++ b/test/alltests.py
@@ -26,17 +26,17 @@ class OpenSIPSCLIUnitTests(unittest.TestCase):
         assert repr(u) == 'x://user:***@host:12/db'
         assert str(u) == 'x://user:pass@host:12/db'
 
-        u = make_url('mysql://opensips:opensipsrw@localhost/opensips')
-        assert repr(u) == 'mysql://opensips:***@localhost/opensips'
-        assert str(u) == 'mysql://opensips:opensipsrw@localhost/opensips'
+        u = make_url('mysql+pymysql://opensips:opensipsrw@localhost/opensips')
+        assert repr(u) == 'mysql+pymysql://opensips:***@localhost/opensips'
+        assert str(u) == 'mysql+pymysql://opensips:opensipsrw@localhost/opensips'
 
-        u = make_url('mysql://opensips:opensipsrw@localhost')
-        assert repr(u) == 'mysql://opensips:***@localhost'
-        assert str(u) == 'mysql://opensips:opensipsrw@localhost'
+        u = make_url('mysql+pymysql://opensips:opensipsrw@localhost')
+        assert repr(u) == 'mysql+pymysql://opensips:***@localhost'
+        assert str(u) == 'mysql+pymysql://opensips:opensipsrw@localhost'
 
-        u = make_url('mysql://root@localhost')
-        assert repr(u) == 'mysql://root@localhost'
-        assert str(u) == 'mysql://root@localhost'
+        u = make_url('mysql+pymysql://root@localhost')
+        assert repr(u) == 'mysql+pymysql://root@localhost'
+        assert str(u) == 'mysql+pymysql://root@localhost'
 
 
 if __name__ == "__main__":

--- a/test/test-database.sh
+++ b/test/test-database.sh
@@ -20,7 +20,7 @@
 CLI_CFG=/tmp/.__cli.cfg
 DB_NAME=_opensips_cli_test
 
-MYSQL_URL=mysql://opensips:opensipsrw@localhost
+MYSQL_URL=mysql+pymysql://opensips:opensipsrw@localhost
 PGSQL_URL=postgresql://opensips:opensipsrw@localhost
 
 TESTS=(

--- a/test/test-database.sh
+++ b/test/test-database.sh
@@ -20,7 +20,7 @@
 CLI_CFG=/tmp/.__cli.cfg
 DB_NAME=_opensips_cli_test
 
-MYSQL_URL=mysql+pymysql://opensips:opensipsrw@localhost
+MYSQL_URL=mysql://opensips:opensipsrw@localhost
 PGSQL_URL=postgresql://opensips:opensipsrw@localhost
 
 TESTS=(


### PR DESCRIPTION
This PR addresses the cluster of packaging issues that prevent clean
installation on systems with newer versions of SQLAlchemy.

## Changes

- Switch MySQL driver from mysqlclient to PyMySQL (pure Python, no C
  compiler or libmysqlclient-dev needed) — closes #152
- Allow SQLAlchemy `>=2`, unblocking installation from system packages
  on Debian Trixie — closes #156, closes #149
- Fix db.py and sqlalchemy_utils.py for SQLAlchemy 1.4/2.0 compatibility
- Fix URL reconstruction to preserve the +pymysql driver suffix
- Remove gcc/libmysqlclient-dev from Debian, RPM, and Docker packaging
- Fix pre-existing TypeError when inserting/updating integer values
- Bump minimum SQLAlchemy requirement to 1.3.16, the first version to support
  `AUTOCOMMIT` isolation level for SQLite

## Also incorporates

- #150 — fix OpenSIPSCLIArgs documentation
- #154 — fix typo in RPM description  
- #155 — point shebangs at python3

## Replaces

- #157 



Thanks, @jwarnier & @etamme, for your contributions!