### PR TITLE
db: use bound parameters instead of manual quote escaping

### DIFF
--- a/opensipscli/db.py
+++ b/opensipscli/db.py
@@ -486,10 +486,10 @@ class osdb(object):
         if not self.__conn:
             raise osdbError("connection not available")
 
-        where_str = self.get_where(filter_keys)
+        where_str, params = self.get_where(filter_keys)
         statement = "DELETE FROM {}{}".format(table, where_str)
         try:
-            self.__conn.execute(text(statement))
+            self.__conn.execute(text(statement), params)
         except sqlalchemy.exc.SQLAlchemyError as ex:
             logger.error("cannot execute query: {}".format(statement))
             logger.error(ex)
@@ -667,13 +667,13 @@ class osdb(object):
         elif type(fields) != list:
             fields = [ fields ]
 
-        where_str = self.get_where(filter_keys)
+        where_str, params = self.get_where(filter_keys)
         statement = "SELECT {} FROM {}{}".format(
                 ", ".join(fields),
                 table,
                 where_str)
         try:
-            result = self.__conn.execute(text(statement))
+            result = self.__conn.execute(text(statement), params)
         except sqlalchemy.exc.SQLAlchemyError as ex:
             logger.error("cannot execute query: {}".format(statement))
             logger.error(ex)
@@ -688,22 +688,18 @@ class osdb(object):
 
     def get_where(self, filter_keys):
         """
-        construct a sql 'where clause' from given filter keys
+        construct a sql 'where clause' from given filter keys, along with
+        the parameters to bind to it
         """
-        if filter_keys:
-            where_str = ""
-            for k, v in filter_keys.items():
-                where_str += " AND {} = ".format(k)
-                if type(v) == int:
-                    where_str += str(v)
-                else:
-                    where_str += "'{}'".format(
-                            v.translate(str.maketrans({'\'': '\\\''})))
-            if where_str != "":
-                where_str = " WHERE " + where_str[5:]
-        else:
-            where_str = ""
-        return where_str
+        if not filter_keys:
+            return "", {}
+
+        where_str = ""
+        params = {}
+        for i, (k, v) in enumerate(filter_keys.items()):
+            where_str += " AND {} = :w{}".format(k, i)
+            params["w{}".format(i)] = v
+        return " WHERE " + where_str[5:], params
 
     def get_role(self, role_name="opensips"):
         """
@@ -790,18 +786,13 @@ class osdb(object):
         if not self.__conn:
             raise osdbError("connection not available")
 
-        values = ""
-        for v in keys.values():
-            values += ", "
-            if type(v) == int:
-                values += str(v)
-            else:
-                values += "'{}'".format(
-                        v.translate(str.maketrans({'\'': '\\\''})))
+        cols = list(keys.keys())
+        params = {"v{}".format(i): keys[k] for i, k in enumerate(cols)}
         statement = "INSERT INTO {} ({}) VALUES ({})".format(
-                table, ", ".join(keys.keys()), values[2:])
+                table, ", ".join(cols),
+                ", ".join(":v{}".format(i) for i in range(len(cols))))
         try:
-            result = self.__conn.execute(text(statement))
+            result = self.__conn.execute(text(statement), params)
         except sqlalchemy.exc.SQLAlchemyError as ex:
             logger.error("cannot execute query: {}".format(statement))
             logger.error(ex)
@@ -883,18 +874,16 @@ class osdb(object):
             raise osdbError("connection not available")
 
         update_str = ""
-        for k, v in update_keys.items():
-            update_str += ", {} = ".format(k)
-            if type(v) == int:
-                update_str += str(v)
-            else:
-                update_str += "'{}'".format(
-                        v.translate(str.maketrans({'\'': '\\\''})))
-        where_str = self.get_where(filter_keys)
+        params = {}
+        for i, (k, v) in enumerate(update_keys.items()):
+            update_str += ", {} = :s{}".format(k, i)
+            params["s{}".format(i)] = v
+        where_str, where_params = self.get_where(filter_keys)
+        params.update(where_params)
         statement = "UPDATE {} SET {}{}".format(table,
                 update_str[2:], where_str)
         try:
-            result = self.__conn.execute(text(statement))
+            result = self.__conn.execute(text(statement), params)
         except sqlalchemy.exc.SQLAlchemyError as ex:
             logger.error("cannot execute query: {}".format(statement))
             logger.error(ex)


### PR DESCRIPTION
`insert()`, `update()` and `get_where()` built their SQL by concatenation and escaped single quotes by backslash-prefixing them (`v.translate(str.maketrans({'\'': '\\\''}))`). That escaping is MySQL-specific and incomplete, and it was applied to every backend.

Two independent problems:

* **`\'` is not an escaped quote outside MySQL.** PostgreSQL runs with `standard_conforming_strings=on` and SQLite follows the standard, so the backslash is literal and the quote closes the string early — the statement breaks, and the remainder of the value is parsed as SQL.
* **Backslashes were never escaped at all.** MySQL treats `\` as an escape character in string literals, so it silently consumed it: `back\slash` was stored and returned as `backslash`, with no error.

`opensipscli/modules/user.py` passes user-supplied usernames and domains through these helpers, so a value containing a quote could alter the surrounding statement.

## Fix

Bind the values as parameters and let the driver quote them, instead of hand-rolling dialect-specific escaping. `get_where()` now returns the clause together with its parameters; its callers (`delete()`, `find()`, `update()`) are updated. `entry_exists()` is covered via `find()`. The `type(v) == int` special-casing is gone — the driver handles typing.

Table and column names stay interpolated: those are identifiers, not values, and come from module constants rather than user input.

As a side effect, the error path now logs the statement with placeholders instead of the values, which could previously include plaintext passwords when `plain_text_passwords` is enabled.

## Verification

Round-tripped hostile values (`o'brien`, `a'; DROP TABLE subscriber; --`, `back\slash`, `both'\mix`) through `insert` / `find` / `entry_exists` / `update` / `delete` against real MariaDB 11, PostgreSQL 16 and SQLite servers.

Before the change: 20 failures — hard errors on SQLite/PostgreSQL, silent data corruption on MySQL.
After: 0 failures on every combination below.

| SQLAlchemy | Python | backends |
|---|---|---|
| 1.3.2 (EL8) | 3.6.8 | MariaDB, PostgreSQL, SQLite |
| 1.3.22 (Bullseye) | 3.9.2 | MariaDB, PostgreSQL, SQLite |
| 1.4.46 (Bookworm) | 3.11.2 | MariaDB, PostgreSQL, SQLite |
| 1.4.54 | 3.14.4 | SQLite |
| 2.0.40 (Trixie) | 3.13.5 | MariaDB, PostgreSQL, SQLite |
| 2.0.52 | 3.12.14 | MariaDB, PostgreSQL, SQLite |
